### PR TITLE
docs: correct upstream repository links

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,12 +6,12 @@ This product includes software developed at:
   - NVIDIA Corporation: SOMA Retargeter (Apache-2.0). The Newton+Warp retargeting
     pipeline, human-to-robot scaler, feet stabilizer, and joint-limit clamper
     modules in this project are adapted from the original soma-retargeter sources.
-    https://github.com/NVlabs/SOMA-Retargeter
+    https://github.com/NVIDIA/SOMA-Retargeter
 
-  - NVIDIA Corporation: holosoma (Apache-2.0). Laplacian interaction-mesh helpers
+  - Amazon FAR: holosoma (Apache-2.0). Laplacian interaction-mesh helpers
     and MPC/SQP retargeting logic in ``hhtools.retarget.interaction_mesh`` were
     adapted from holosoma interaction-mesh retargeting utilities.
-    https://github.com/NVIDIA-Omniverse/holosoma
+    https://github.com/amazon-far/holosoma
 
   - Meta Platforms, Inc. and affiliates: AI4AnimationPy (Apache-2.0). The public
     API shape for Motion import and the NPZ schema were inspired by the
@@ -47,7 +47,7 @@ and comply with the respective terms):
   - OMOMO        : https://github.com/lijiaman/omomo_release
   - PHUMA        : https://github.com/DAVIAN-Robotics/PHUMA
   - GVHMR        : https://github.com/zju3dv/GVHMR
-  - holosoma / meshmimic : https://github.com/NVIDIA-Omniverse/holosoma
+  - holosoma / meshmimic : https://github.com/amazon-far/holosoma
   - LAFAN1       : https://github.com/ubisoft/ubisoft-laforge-animation-dataset
   - 100STYLE     : https://www.ianxmason.com/100style/
 

--- a/assets/motions/meshmimic/holosoma/source.yaml
+++ b/assets/motions/meshmimic/holosoma/source.yaml
@@ -6,7 +6,7 @@
 
 schema_version: 1
 source: holosoma
-source_url: https://github.com/HumanoidTeam/holosoma
+source_url: https://github.com/amazon-far/holosoma
 source_license: Apache-2.0 (holosoma code); motion data derives from holosoma climb demo bundle
 task: climbing / parkour (human + static terrain)
 

--- a/framework.md
+++ b/framework.md
@@ -132,7 +132,7 @@ Web UI 根据动作是否携带 `objects` / `terrain` 自动推荐后端；用�
 
 ## 5. Newton IK 引擎（`newton_basic`）
 
-> 改编自 NVIDIA [SOMA-Retargeter](https://github.com/NVlabs/SOMA-Retargeter)（Apache-2.0）。
+> 改编自 NVIDIA [SOMA-Retargeter](https://github.com/NVIDIA/SOMA-Retargeter)（Apache-2.0）。
 
 ### 5.1 管线概览
 
@@ -183,7 +183,7 @@ RetargetedMotion
 
 ## 6. MPC/SQP 引擎（`interaction_mesh`）
 
-> 拉普拉斯交互网格思路参考 [holosoma](https://github.com/NVIDIA-Omniverse/holosoma) interaction-mesh retargeting（Apache-2.0）。
+> 拉普拉斯交互网格思路参考 [holosoma](https://github.com/amazon-far/holosoma) interaction-mesh retargeting（Apache-2.0）。
 
 ### 6.1 为何需要第二套引擎
 
@@ -313,8 +313,8 @@ J_L = \mathrm{kron}(L, I_3) \cdot J_V, \quad
 
 | 上游 | 许可 | 本仓库使用 |
 |------|------|-----------|
-| [SOMA-Retargeter](https://github.com/NVlabs/SOMA-Retargeter) | Apache-2.0 | Newton IK 管线、Scaler、FeetStabilizer |
-| [holosoma](https://github.com/NVIDIA-Omniverse/holosoma) | Apache-2.0 | 拉普拉斯交互网格、MPC/SQP 公式 |
+| [SOMA-Retargeter](https://github.com/NVIDIA/SOMA-Retargeter) | Apache-2.0 | Newton IK 管线、Scaler、FeetStabilizer |
+| [holosoma](https://github.com/amazon-far/holosoma) | Apache-2.0 | 拉普拉斯交互网格、MPC/SQP 公式 |
 | [ai4animationpy](https://github.com/facebookresearch/ai4animationpy) | Apache-2.0 | NPZ schema 与 API 形态参考（代码全新编写） |
 | [Newton](https://github.com/newton-physics/newton) | Apache-2.0 | IK 求解器 |
 | [NVIDIA Warp](https://github.com/NVIDIA/warp) | Apache-2.0 | GPU 加速 |
@@ -341,7 +341,7 @@ J_L = \mathrm{kron}(L, I_3) \cdot J_V, \quad
 | OmniContact-Dataset | [lightcone02/OmniContact-Dataset](https://huggingface.co/datasets/lightcone02/OmniContact-Dataset) | 光学动捕 HOI（raw_mocap BVH + 物体 CSV） |
 | PHUMA | [DAVIAN-Robotics/PHUMA](https://github.com/DAVIAN-Robotics/PHUMA) | 精选人体动作 |
 | GVHMR | [zju3dv/GVHMR](https://github.com/zju3dv/GVHMR) | 视频单目 HMR |
-| meshmimic / holosoma | [NVIDIA-Omniverse/holosoma](https://github.com/NVIDIA-Omniverse/holosoma) | 跑酷地形片段 |
+| meshmimic / holosoma | [amazon-far/holosoma](https://github.com/amazon-far/holosoma) | 跑酷地形片段 |
 | LAFAN1 | [ubisoft/ubisoft-laforge-animation-dataset](https://github.com/ubisoft/ubisoft-laforge-animation-dataset) | BVH 动捕 |
 | PARC MS | holosoma 生态 | 地形+动作 pickle |
 

--- a/hhtools/retarget/newton_basic/__init__.py
+++ b/hhtools/retarget/newton_basic/__init__.py
@@ -1,7 +1,7 @@
 """Newton-based IK retargeting pipeline — Stage 1 (pure NumPy).
 
 This package is an Apache-2.0 re-implementation of the core blocks from
-soma-retargeter (https://github.com/NVlabs/SOMA-Retargeter), rewritten
+soma-retargeter (https://github.com/NVIDIA/SOMA-Retargeter), rewritten
 against the hhtools :class:`~hhtools.core.motion.Motion` /
 :class:`~hhtools.core.hierarchy.Hierarchy` / :class:`~hhtools.robot.base
 .RobotModel` contracts.  See the project-root ``NOTICE`` for full

--- a/hhtools/retarget/newton_basic/feet_stabilizer.py
+++ b/hhtools/retarget/newton_basic/feet_stabilizer.py
@@ -19,7 +19,7 @@ trajectories in, constrained trajectories out) while we wait on the solver.
 Attribution:
   Portions of the constraint formulas are adapted from soma-retargeter
   (Apache-2.0).
-  https://github.com/NVlabs/SOMA-Retargeter
+  https://github.com/NVIDIA/SOMA-Retargeter
   SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 """
 

--- a/hhtools/retarget/newton_basic/ik_objectives.py
+++ b/hhtools/retarget/newton_basic/ik_objectives.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Portions adapted from soma-retargeter (Apache-2.0).
-# See https://github.com/NVlabs/SOMA-Retargeter and the project root NOTICE.
+# See https://github.com/NVIDIA/SOMA-Retargeter and the project root NOTICE.
 """Custom Newton IK objectives used by ``newton_basic`` pipeline.
 
 Currently only :class:`IKSmoothJointFilter` — a soft penalty that pulls every

--- a/hhtools/retarget/newton_basic/joint_limit_clamper.py
+++ b/hhtools/retarget/newton_basic/joint_limit_clamper.py
@@ -7,7 +7,7 @@ limit_upper`` fields that :mod:`hhtools.robot.loader` already exposes so the
 module is trivially unit-testable on CI machines without a GPU.
 
 Original implementation: soma-retargeter, licensed under Apache-2.0.
-  https://github.com/NVlabs/SOMA-Retargeter
+  https://github.com/NVIDIA/SOMA-Retargeter
   SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 
 Key differences from the original:

--- a/hhtools/retarget/newton_basic/pipeline.py
+++ b/hhtools/retarget/newton_basic/pipeline.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Portions adapted from soma-retargeter (Apache-2.0).
-# See https://github.com/NVlabs/SOMA-Retargeter and the project root NOTICE.
+# See https://github.com/NVIDIA/SOMA-Retargeter and the project root NOTICE.
 """Newton-based IK retargeting pipeline (stage 2).
 
 This is the hhtools port of ``soma_retargeter.pipelines.newton_pipeline`` —

--- a/hhtools/retarget/newton_basic/robot_model.py
+++ b/hhtools/retarget/newton_basic/robot_model.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Portions adapted from soma-retargeter (Apache-2.0).
-# See https://github.com/NVlabs/SOMA-Retargeter and the project root NOTICE.
+# See https://github.com/NVIDIA/SOMA-Retargeter and the project root NOTICE.
 """Newton-model construction from hhtools robot presets.
 
 The stage-2 IK pipeline consumes Newton :class:`newton.Model` objects rather

--- a/hhtools/retarget/newton_basic/scaler.py
+++ b/hhtools/retarget/newton_basic/scaler.py
@@ -10,7 +10,7 @@ an FK pass and stay on pure NumPy.
 Attribution:
   Portions of the scaling formula and offset semantics are adapted from
   soma-retargeter (Apache-2.0).
-  https://github.com/NVlabs/SOMA-Retargeter
+  https://github.com/NVIDIA/SOMA-Retargeter
   SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 
 The upstream scaler also ships a long chain of ``_enforce_*`` post-processors


### PR DESCRIPTION
## Summary

Fix incorrect repository links and attribution.

| Upstream | Original link | Corrected link | Affected files |
|---|---|---|---|
| holosoma | `https://github.com/NVIDIA-Omniverse/holosoma` | `https://github.com/amazon-far/holosoma` | `NOTICE`, `framework.md` |
| holosoma source metadata | `https://github.com/HumanoidTeam/holosoma` | `https://github.com/amazon-far/holosoma` | `assets/motions/meshmimic/holosoma/source.yaml` |
| SOMA-Retargeter | `https://github.com/NVlabs/SOMA-Retargeter` | `https://github.com/NVIDIA/SOMA-Retargeter` | `NOTICE`, `framework.md`, `hhtools/retarget/newton_basic/` |

Additional attribution correction:

- Change holosoma attribution from `NVIDIA Corporation` to `Amazon FAR` in `NOTICE`.

## Validation

- `git diff --check`
- Confirmed the repository no longer contains:
  - `github.com/NVIDIA-Omniverse/holosoma`
  - `github.com/HumanoidTeam/holosoma`
  - `github.com/NVlabs/SOMA-Retargeter`
- Ruff was not run locally.